### PR TITLE
Fix TypeError

### DIFF
--- a/lib/performance.js
+++ b/lib/performance.js
@@ -38,7 +38,7 @@ exports.runBenchmarks = function(options)
 	options = options || {};
 	spanMs = 1000 * options.seconds || TIME;
 	if (options.file) console = new Console(createWriteStream(options.file));
-	if (!options.json) log.info('Running benchmarks for %s ms', spanMs);
+	if (!options.json) Log.info('Running benchmarks for %s ms', spanMs);
 	var longArray = [];
 	var object = {};
 	for (var i = 0; i < ARRAY_SIZE; i++)


### PR DESCRIPTION
And you actually could have simply used console.log or console.info. log library dependency is relevant here.